### PR TITLE
Update code-splitting-libraries.md

### DIFF
--- a/content/guides/code-splitting-libraries.md
+++ b/content/guides/code-splitting-libraries.md
@@ -75,7 +75,7 @@ module.exports = function(env) {
 }
 ```
 
-On running `webpack` now, we see that two bundles have been created. If you inspect these though, you will find that the code for `moment` is present in both the files!
+On running `webpack` now, we see that two bundles have been created. If you inspect these though, you will find that the code for `moment` is present in both the files! The reason for that is `moment` is a dependency of the main application ( e.g. index.js ) and each entry point will bundle its own dependencies.
 
 It is for this reason, that we will need to use the [CommonsChunkPlugin](/plugins/commons-chunk-plugin).
 


### PR DESCRIPTION
Explain why multiple entry doesn't work in the case of code splitting library.

1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Make sure your PR complies with [the writer's guide](https://webpack.js.org/writers-guide/).
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
4. Remove these instructions from your PR as they are for your eyes only.
